### PR TITLE
Ensure all assets are included

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,9 +56,9 @@ module.exports = {
     });
 
     const assetsTree = new Funnel(tree, {
-      include: ['**/*'],
-      srcDir: 'assets',
-      destDir: 'staticboot/assets'
+      exclude: ['fastboot/**/*', 'index.html', 'tests/**/*', 'testem.js'],
+      srcDir: './',
+      destDir: 'staticboot'
     });
 
     let mergeOptions = {};


### PR DESCRIPTION
This PR ensures that all required assets are included in the outputted build.

While I'm not certain this is the correct fix, prior to this change, assets found in an applications public directory and assets included by other add-ons were not included in the outputted build.