### PR TITLE
Re-implement includeClientScripts option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ An array of paths that the addon will hit when the static pages are generated.
 Destination directory for the staticboot build within `dist`.
 *Default:* `staticboot`
 
+### includeClientScripts
+Whether or not to include the client side scripts (app.js / vendor.js) in the generated pages.
+*Default:* `true`
+
 ##`link-to`
 Use `link-to` helpers as you would normally. The `href` attribute will be modified with a path to a static page.
 

--- a/index.js
+++ b/index.js
@@ -49,18 +49,6 @@ module.exports = {
       return tree;
     }
 
-    // If required, remove client scripts
-    if (!this.options.includeClientScripts) {
-      const replaceOptions = {
-        files: ['index.html'],
-        patterns: [{
-          match: /<.*?script src=\"\/assets\/.*.js\".*?>.*?<\/.*?script.*?>/g,
-          replacement: ''
-        }]
-      };
-      tree = replace(tree, replaceOptions);
-    }
-
     const trees = [tree];
     const destDirIsRoot = this.options.destDir === '';
     const mergeOptions = {};
@@ -68,6 +56,18 @@ module.exports = {
     let staticBootTree = new StaticBootBuild(tree, {
       paths: this.options.paths
     });
+
+    // If required, remove client scripts
+    if (!this.options.includeClientScripts) {
+      const replaceOptions = {
+        files: ['**/index.html'],
+        patterns: [{
+          match: /<.*?script src=\"\/assets\/.*.js\".*?>.*?<\/.*?script.*?>/g,
+          replacement: ''
+        }]
+      };
+      staticBootTree = replace(staticBootTree, replaceOptions);
+    }
 
     staticBootTree = new Funnel(staticBootTree, {
       include: this.options.include,

--- a/index.js
+++ b/index.js
@@ -4,11 +4,13 @@
 const mergeTrees = require('broccoli-merge-trees');
 const StaticBootBuild = require('./lib/broccoli/staticboot');
 const Funnel = require('broccoli-funnel');
+const replace = require('broccoli-replace');
 
 const defaultOptions = {
   paths: [],
   destDir: 'staticboot',
-  include: ['**/*']
+  include: ['**/*'],
+  includeClientScripts: true
 };
 
 module.exports = {
@@ -46,6 +48,19 @@ module.exports = {
     if (type !== 'all' || this.app.options.__is_building_fastboot__) {
       return tree;
     }
+
+    // If required, remove client scripts
+    if (!this.options.includeClientScripts) {
+      const replaceOptions = {
+        files: ['index.html'],
+        patterns: [{
+          match: /<.*?script src=\"\/assets\/.*.js\".*?>.*?<\/.*?script.*?>/g,
+          replacement: ''
+        }]
+      };
+      tree = replace(tree, replaceOptions);
+    }
+
     const trees = [tree];
     const destDirIsRoot = this.options.destDir === '';
     const mergeOptions = {};

--- a/test/commands/build-nodetest.js
+++ b/test/commands/build-nodetest.js
@@ -47,6 +47,9 @@ describe('default configuration', function() {
         expect(app.filePath('dist/staticboot/index.html')).to.have.content.that.match(
           /<h1>Dummy App<\/h1>/
         );
+        expect(app.filePath('dist/staticboot/index.html')).to.have.content.that.match(
+          /<.*?script src=\"\/assets\/.*.js\".*?>.*?<\/.*?script.*?>/
+        );
 
         // https://github.com/chaijs/chai-fs/issues/9#issuecomment-223789489
         expect(app.filePath('dist/staticboot/package.json')).to.not.be.a.path();
@@ -74,6 +77,9 @@ describe('custom configuration', function() {
         expect(app.filePath('dist/index.html')).to.be.a.file();
         expect(app.filePath('dist/index.html')).to.have.content.that.match(
           /<h1>Dummy App<\/h1>/
+        );
+        expect(app.filePath('dist/index.html')).to.not.have.content.that.match(
+          /<.*?script src=\"\/assets\/.*.js\".*?>.*?<\/.*?script.*?>/
         );
       });
   });

--- a/tests/fixtures/custom/ember-cli-build.js
+++ b/tests/fixtures/custom/ember-cli-build.js
@@ -6,7 +6,8 @@ module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
     'ember-cli-staticboot': {
       paths: ['/'],
-      destDir: ''
+      destDir: '',
+      includeClientScripts: false
     },
   });
 


### PR DESCRIPTION
This PR re-introduces and fixes the `includeClientScripts` option that was removed previously due to being broken.

As we don't require the generated static build to be a fully functioning ember application, it doesn't make sense for the client scripts to be included. Using this option actually reduces the page weight of our homepage by just under 75%!