### PR TITLE
Resolve ember-try deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
-    "ember-try": "0.2.4",
     "glob": "^7.0.5",
     "jsonfile": "^2.3.1",
     "loader.js": "^4.0.10",


### PR DESCRIPTION
EmberCLI now includes ember-try by default so it can be safely removed from the `package.json`.